### PR TITLE
Add support for password strings

### DIFF
--- a/aussiebb/__init__.py
+++ b/aussiebb/__init__.py
@@ -51,7 +51,6 @@ class AussieBB(BaseClass):
         ```
         """
         super().__init__(username, password, debug, services_cache_time)
-
         if session is None:
             self.session = requests.Session()
         else:

--- a/aussiebb/__init__.py
+++ b/aussiebb/__init__.py
@@ -33,7 +33,7 @@ class AussieBB(BaseClass):
     def __init__(
         self,
         username: str,
-        password: str | SecretStr,
+        password: SecretStr | str,
         debug: bool = False,
         services_cache_time: int = 28800,
         session: Optional[requests.sessions.Session] = None,

--- a/aussiebb/__init__.py
+++ b/aussiebb/__init__.py
@@ -33,7 +33,7 @@ class AussieBB(BaseClass):
     def __init__(
         self,
         username: str,
-        password: SecretStr,
+        password: str | SecretStr,
         debug: bool = False,
         services_cache_time: int = 28800,
         session: Optional[requests.sessions.Session] = None,
@@ -51,6 +51,7 @@ class AussieBB(BaseClass):
         ```
         """
         super().__init__(username, password, debug, services_cache_time)
+
         if session is None:
             self.session = requests.Session()
         else:

--- a/aussiebb/asyncio/__init__.py
+++ b/aussiebb/asyncio/__init__.py
@@ -42,7 +42,7 @@ class AussieBB(BaseClass):
     def __init__(
         self,
         username: str,
-        password: SecretStr,
+        password: SecretStr | str,
         session: Optional[aiohttp.client.ClientSession] = None,
         debug: bool = False,
         services_cache_time: int = 28800,

--- a/aussiebb/baseclass.py
+++ b/aussiebb/baseclass.py
@@ -35,7 +35,7 @@ class BaseClass:
     def __init__(
         self,
         username: str,
-        password: SecretStr,
+        password: SecretStr | str,
         debug: bool = False,
         services_cache_time: int = 28800,
         logger: logging.Logger = logging.getLogger(),
@@ -50,7 +50,10 @@ class BaseClass:
         self.services_last_update = -1
         self.services: List[Dict[str, Any]] = []
         self.username = username
-        self.password = password
+        if isinstance(password, SecretStr):
+            self.password = password
+        else:
+            self.password = SecretStr(password)
         self.logger = logger
         self.debug = debug
 


### PR DESCRIPTION
Home Assistant project doesnt want to depend on Pydantic on the implementation side, so this adds support for plain `str` passwords which get converted to `SecretStr` at init.